### PR TITLE
이메일 오류 수정과 스타일리스트 추천 방식 변경

### DIFF
--- a/src/main/java/com/apptive/marico/controller/HomeController.java
+++ b/src/main/java/com/apptive/marico/controller/HomeController.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
+
 @RestController
 @RequestMapping("/api/home")
 @RequiredArgsConstructor
@@ -18,14 +20,21 @@ public class HomeController {
         return ResponseEntity.ok(homeService.filter(stylistFilterDto));
     }
 
+    // 스타일리스트 상세 페이지 조회
     @GetMapping("/stylist/{stylist_id}")
     public ResponseEntity<?> stylistDetail(@PathVariable Long stylist_id) {
         return ResponseEntity.ok(homeService.stylistDetail(stylist_id));
     }
 
-    @PostMapping("/member/service/{service_id}")
-    public ResponseEntity<?> requestService(@PathVariable Long service_id) {
-        return ResponseEntity.ok(homeService.stylistDetail(stylist_id));
+    // 스타일리스트 서비스 신청 조회
+    @GetMapping("/member/application/{service_id}")
+    public ResponseEntity<?> loadService(Principal principal, @PathVariable Long service_id) {
+        return ResponseEntity.ok(homeService.loadApplication(principal.getName(), service_id));
+    }
+    // 스타일리스트 서비스 신청 하기
+    @PostMapping("/member/application/{service_id}")
+    public ResponseEntity<?> addRequestService(Principal principal, @PathVariable Long service_id) {
+        return ResponseEntity.ok(homeService.loadApplication(principal.getName(), service_id));
     }
 
 }

--- a/src/main/java/com/apptive/marico/controller/HomeController.java
+++ b/src/main/java/com/apptive/marico/controller/HomeController.java
@@ -22,4 +22,10 @@ public class HomeController {
     public ResponseEntity<?> stylistDetail(@PathVariable Long stylist_id) {
         return ResponseEntity.ok(homeService.stylistDetail(stylist_id));
     }
+
+    @PostMapping("/member/service/{service_id}")
+    public ResponseEntity<?> requestService(@PathVariable Long service_id) {
+        return ResponseEntity.ok(homeService.stylistDetail(stylist_id));
+    }
+
 }

--- a/src/main/java/com/apptive/marico/controller/HomeController.java
+++ b/src/main/java/com/apptive/marico/controller/HomeController.java
@@ -1,0 +1,25 @@
+package com.apptive.marico.controller;
+
+
+import com.apptive.marico.dto.stylistService.StylistFilterDto;
+import com.apptive.marico.service.HomeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/home")
+@RequiredArgsConstructor
+public class HomeController {
+
+    private final HomeService homeService;
+    @GetMapping("/filter")
+    public ResponseEntity<?> stylistFilter(@RequestBody StylistFilterDto stylistFilterDto) {
+        return ResponseEntity.ok(homeService.filter(stylistFilterDto));
+    }
+
+    @GetMapping("/stylist/{stylist_id}")
+    public ResponseEntity<?> stylistDetail(@PathVariable Long stylist_id) {
+        return ResponseEntity.ok(homeService.stylistDetail(stylist_id));
+    }
+}

--- a/src/main/java/com/apptive/marico/controller/MemberMypageController.java
+++ b/src/main/java/com/apptive/marico/controller/MemberMypageController.java
@@ -1,5 +1,6 @@
 package com.apptive.marico.controller;
 
+import com.apptive.marico.dto.AccountDto;
 import com.apptive.marico.dto.findId.SendEmailRequestDto;
 import com.apptive.marico.dto.mypage.member.MemberMypageDto;
 import com.apptive.marico.dto.mypage.member.MemberMypageEditDto;
@@ -99,5 +100,13 @@ public class MemberMypageController {
         return ResponseEntity.ok(new ApiUtils.ApiSuccess<>(memberMyPageService.deleteMember(principal.getName())));
     }
 
+    @GetMapping("/account")
+    public ResponseEntity<?> loadAccount(Principal principal) {
+        return ResponseEntity.ok(ApiUtils.success(memberMyPageService.loadAccount(principal.getName())));
+    }
+    @PostMapping("/account")
+    public ResponseEntity<?> addAccount(Principal principal, @RequestBody AccountDto accountDto) {
+        return ResponseEntity.ok(ApiUtils.success(memberMyPageService.addAccount(principal.getName(), accountDto)));
+    }
 
 }

--- a/src/main/java/com/apptive/marico/controller/MemberMypageController.java
+++ b/src/main/java/com/apptive/marico/controller/MemberMypageController.java
@@ -6,6 +6,7 @@ import com.apptive.marico.dto.mypage.member.MemberMypageEditDto;
 import com.apptive.marico.dto.mypage.member.PasswordDto;
 import com.apptive.marico.dto.mypage.member.LikedStylistListDto;
 import com.apptive.marico.dto.verificationToken.SendEmailResponseDto;
+import com.apptive.marico.exception.CustomException;
 import com.apptive.marico.service.MemberMypageService;
 import com.apptive.marico.service.VerificationTokenService;
 import com.apptive.marico.utils.ApiUtils;
@@ -17,6 +18,8 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.security.Principal;
+
+import static com.apptive.marico.exception.ErrorCode.AUTHORIZATION_NOT_FOUND;
 
 @RestController
 @RequestMapping("/api/mypage/member")
@@ -76,16 +79,20 @@ public class MemberMypageController {
 
     @PostMapping("/email/verification-code")
     public ResponseEntity<SendEmailResponseDto> createVerificationCode(@RequestBody SendEmailRequestDto sendEmailRequestDto) {
-        return ResponseEntity.ok(new SendEmailResponseDto(verificationTokenService.createVerificationTokenForSign(sendEmailRequestDto.getEmail())));
+        return ResponseEntity.ok(new SendEmailResponseDto(verificationTokenService.createVerificationTokenForChangeEmail(sendEmailRequestDto.getEmail())));
     }
 
     @GetMapping("/email/verification-code")
     public ResponseEntity<?> checkVerificationCode(Principal principal, @RequestParam String code) {
+        System.out.println(code);
         return ResponseEntity.ok(new ApiUtils.ApiSuccess<>(verificationTokenService.verifyUserEmailForSign(code)));
     }
 
-    @PostMapping("/email")
+    @PatchMapping("/email")
     public ResponseEntity<?> changeEmail(Principal principal, @RequestBody SendEmailRequestDto sendEmailRequestDto) {
+        if (principal == null) {
+            throw new CustomException(AUTHORIZATION_NOT_FOUND);
+        }
         return ResponseEntity.ok(new ApiUtils.ApiSuccess<>(memberMyPageService.changeEmail(principal.getName(), sendEmailRequestDto.getEmail())));
     }
 

--- a/src/main/java/com/apptive/marico/controller/ServiceInquiryController.java
+++ b/src/main/java/com/apptive/marico/controller/ServiceInquiryController.java
@@ -5,10 +5,13 @@ import com.apptive.marico.dto.stylistService.InquiryDto;
 import com.apptive.marico.service.InquiryService;
 import com.apptive.marico.utils.ApiUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.security.Principal;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/service/inquiry")
@@ -29,6 +32,13 @@ public class ServiceInquiryController {
     @GetMapping("/stylist/{inquiry_id}")
     public ResponseEntity<?> loadStylistInquiry(Principal principal, @PathVariable Long inquiry_id) {
         return ResponseEntity.ok(ApiUtils.success(inquiryService.loadStylistInquiry(principal.getName(), inquiry_id)));
+    }
+
+    @PostMapping(value = "/stylist/{inquiry_id}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<?> addStylistInquiry(Principal principal,@PathVariable Long inquiry_id, @RequestPart InquiryDto.InquiryAnswerContentDto answerContentDto ,@RequestPart List<MultipartFile> answerImgs) {
+        System.out.println(answerImgs.get(0).getOriginalFilename());
+        System.out.println(answerContentDto.getResponseContent());
+        return ResponseEntity.ok(ApiUtils.success(inquiryService.addInquiryAnswer(principal.getName(), inquiry_id, answerContentDto.getResponseContent(), answerImgs)));
     }
 
     @GetMapping("/member/{inquiry_id}")

--- a/src/main/java/com/apptive/marico/controller/ServiceInquiryController.java
+++ b/src/main/java/com/apptive/marico/controller/ServiceInquiryController.java
@@ -20,8 +20,8 @@ public class ServiceInquiryController {
 
     private final InquiryService inquiryService;
     @PostMapping
-    public ResponseEntity<?> addInquiry(Principal principal, @RequestBody InquiryDto inquiryDto) {
-        return ResponseEntity.ok(ApiUtils.success(inquiryService.addInquiry(principal.getName(), inquiryDto)));
+    public ResponseEntity<?> addInquiry(Principal principal,@RequestPart List<MultipartFile> image, @RequestPart InquiryDto inquiryDto) {
+        return ResponseEntity.ok(ApiUtils.success(inquiryService.addInquiry(principal.getName(), image ,inquiryDto)));
     }
 
     @GetMapping

--- a/src/main/java/com/apptive/marico/controller/ServiceInquiryController.java
+++ b/src/main/java/com/apptive/marico/controller/ServiceInquiryController.java
@@ -35,7 +35,7 @@ public class ServiceInquiryController {
     }
 
     @PostMapping(value = "/stylist/{inquiry_id}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-    public ResponseEntity<?> addStylistInquiry(Principal principal,@PathVariable Long inquiry_id, @RequestPart InquiryDto.InquiryAnswerContentDto answerContentDto ,@RequestPart List<MultipartFile> answerImgs) {
+    public ResponseEntity<?> addStylistInquiryAnswer(Principal principal,@PathVariable Long inquiry_id, @RequestPart InquiryDto.InquiryAnswerContentDto answerContentDto ,@RequestPart List<MultipartFile> answerImgs) {
         System.out.println(answerImgs.get(0).getOriginalFilename());
         System.out.println(answerContentDto.getResponseContent());
         return ResponseEntity.ok(ApiUtils.success(inquiryService.addInquiryAnswer(principal.getName(), inquiry_id, answerContentDto.getResponseContent(), answerImgs)));

--- a/src/main/java/com/apptive/marico/controller/StylistMypageController.java
+++ b/src/main/java/com/apptive/marico/controller/StylistMypageController.java
@@ -69,8 +69,8 @@ public class StylistMypageController {
     }
 
     @PostMapping("/style")
-    public ResponseEntity<?> addMyStyle(Principal principal, @RequestBody StyleDto styleDto) {
-        return ResponseEntity.ok(ApiUtils.success(stylistMypageService.addStyle(principal.getName(), styleDto)));
+    public ResponseEntity<?> addMyStyle(Principal principal,@RequestPart MultipartFile image ,@RequestPart StyleDto styleDto) {
+        return ResponseEntity.ok(ApiUtils.success(stylistMypageService.addStyle(principal.getName(), image,styleDto)));
     }
 
     @DeleteMapping("/style")

--- a/src/main/java/com/apptive/marico/controller/StylistMypageController.java
+++ b/src/main/java/com/apptive/marico/controller/StylistMypageController.java
@@ -15,8 +15,10 @@ import com.apptive.marico.utils.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.security.Principal;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/mypage/stylist")
@@ -37,8 +39,8 @@ public class StylistMypageController {
     }
 
     @PostMapping("/information")
-    public ResponseEntity<?> editInf(Principal principal, @RequestBody StylistMypageEditDto stylistMypageEditDto) {
-        return ResponseEntity.ok(ApiUtils.success(stylistMypageService.editInformation(principal.getName(), stylistMypageEditDto)));
+    public ResponseEntity<?> editInf(Principal principal, @RequestPart MultipartFile profileImage, @RequestPart StylistMypageEditDto stylistMypageEditDto) {
+        return ResponseEntity.ok(ApiUtils.success(stylistMypageService.editInformation(principal.getName(), profileImage ,stylistMypageEditDto)));
     }
 
     @GetMapping("/stylist-service")

--- a/src/main/java/com/apptive/marico/controller/StylistMypageController.java
+++ b/src/main/java/com/apptive/marico/controller/StylistMypageController.java
@@ -1,5 +1,6 @@
 package com.apptive.marico.controller;
 
+import com.apptive.marico.dto.AccountDto;
 import com.apptive.marico.dto.findId.SendEmailRequestDto;
 import com.apptive.marico.dto.mypage.member.PasswordDto;
 import com.apptive.marico.dto.stylist.DeleteStyleDto;
@@ -109,4 +110,14 @@ public class StylistMypageController {
     public ResponseEntity<?> deleteStylist(Principal principal) {
         return ResponseEntity.ok(new ApiUtils.ApiSuccess<>(stylistMypageService.deleteStylist(principal.getName())));
     }
+
+    @GetMapping("/account")
+    public ResponseEntity<?> loadAccount(Principal principal) {
+        return ResponseEntity.ok(ApiUtils.success(stylistMypageService.loadAccount(principal.getName())));
+    }
+    @PostMapping("/account")
+    public ResponseEntity<?> addAccount(Principal principal, @RequestBody AccountDto accountDto) {
+        return ResponseEntity.ok(ApiUtils.success(stylistMypageService.addAccount(principal.getName(), accountDto)));
+    }
+
 }

--- a/src/main/java/com/apptive/marico/controller/auth/UserAuthController.java
+++ b/src/main/java/com/apptive/marico/controller/auth/UserAuthController.java
@@ -66,7 +66,7 @@ public class UserAuthController {
 
     @PostMapping("/logout")
     public ResponseEntity<?> logout(@RequestBody TokenRequestDto requestDto) {
-        customUserDetailsService.logout(requestDto);
+        customUserDetailsService.logout(requestDto.getAccessToken());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/apptive/marico/controller/auth/UserAuthController.java
+++ b/src/main/java/com/apptive/marico/controller/auth/UserAuthController.java
@@ -53,6 +53,7 @@ public class UserAuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<?> refreshToken(HttpServletRequest request,  HttpServletResponse response, @CookieValue String refreshToken) {
+        System.out.println(refreshToken);
         String accessToken = request.getHeader("authorization").substring(7);
         TokenDto tokenDto = customUserDetailsService.refreshToken(accessToken, refreshToken);
         response.setHeader("Set-Cookie",

--- a/src/main/java/com/apptive/marico/dto/AccountDto.java
+++ b/src/main/java/com/apptive/marico/dto/AccountDto.java
@@ -1,0 +1,13 @@
+package com.apptive.marico.dto;
+
+import com.apptive.marico.entity.Career;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class AccountDto {
+    private String bank;
+    private String accountNumber;
+    private String accountHolder;
+}

--- a/src/main/java/com/apptive/marico/dto/ServiceApplicationDto.java
+++ b/src/main/java/com/apptive/marico/dto/ServiceApplicationDto.java
@@ -1,0 +1,15 @@
+package com.apptive.marico.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ServiceApplicationDto {
+
+    private AccountDto refundAccount;
+    private AccountDto stylistAccount;
+    private int price;
+
+}

--- a/src/main/java/com/apptive/marico/dto/stylist/StylistDetailDto.java
+++ b/src/main/java/com/apptive/marico/dto/stylist/StylistDetailDto.java
@@ -1,0 +1,44 @@
+package com.apptive.marico.dto.stylist;
+
+import com.apptive.marico.dto.CareerDto;
+import com.apptive.marico.dto.stylist.service.StylistServiceDto;
+import com.apptive.marico.entity.Stylist;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+public class StylistDetailDto {
+    private String profileImage;
+    private String stageName;
+    private String oneLineIntroduction;
+    private String stylistIntroduction;
+    private String city;
+    private String state;
+    private List<StyleDto> styleDtoList;
+    private List<CareerDto> careerDtoList;
+    private List<StylistServiceDto> stylistServiceDtoList;
+
+    public static StylistDetailDto toDto(Stylist stylist) {
+        return StylistDetailDto.builder()
+                .profileImage(stylist.getProfileImage())
+                .stageName(stylist.getStageName())
+                .oneLineIntroduction(stylist.getOneLineIntroduction())
+                .stylistIntroduction(stylist.getStylistIntroduction())
+                .city(stylist.getCity())
+                .state(stylist.getState())
+                .styleDtoList(stylist.getStyles().stream()
+                        .map(StyleDto::toDto)
+                        .collect(Collectors.toList()))
+                .careerDtoList(stylist.getCareer().stream()
+                        .map(CareerDto::toDto)
+                        .collect(Collectors.toList()))
+                .stylistServiceDtoList(stylist.getStylistServices().stream()
+                        .map(StylistServiceDto::toDto)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/apptive/marico/dto/stylist/StylistMypageEditDto.java
+++ b/src/main/java/com/apptive/marico/dto/stylist/StylistMypageEditDto.java
@@ -6,12 +6,14 @@ import com.apptive.marico.entity.Career;
 import com.apptive.marico.entity.Stylist;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Builder
 @Getter
+@Setter
 public class StylistMypageEditDto {
     private String profile_image;
     private String nickname;

--- a/src/main/java/com/apptive/marico/dto/stylistService/InquiryDto.java
+++ b/src/main/java/com/apptive/marico/dto/stylistService/InquiryDto.java
@@ -3,8 +3,11 @@ package com.apptive.marico.dto.stylistService;
 
 import com.apptive.marico.dto.stylist.service.StylistServiceDto;
 import com.apptive.marico.entity.ServiceInquiry;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +29,14 @@ public class InquiryDto {
         private String title;
         private String content;
         private List<String> img = new ArrayList<>();
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class InquiryAnswerContentDto {
+        private String responseContent;
     }
 
     public static InquiryDto toDto(ServiceInquiry serviceInquiry) {

--- a/src/main/java/com/apptive/marico/dto/stylistService/InquiryDto.java
+++ b/src/main/java/com/apptive/marico/dto/stylistService/InquiryDto.java
@@ -20,6 +20,10 @@ public class InquiryDto {
     private String title;
     private String content;
     private List<String> img = new ArrayList<>();
+    private String responseContent;
+    private List<String> responseImg = new ArrayList<>();
+
+    private boolean answerComplete = false;
 
 
     @Builder
@@ -45,6 +49,9 @@ public class InquiryDto {
                 .title(serviceInquiry.getTitle())
                 .content(serviceInquiry.getContent())
                 .img(serviceInquiry.getInquiryImg())
+                .responseContent(serviceInquiry.getResponseContent())
+                .responseImg(serviceInquiry.getResponseImg())
+                .answerComplete(serviceInquiry.isAnswerComplete())
                 .build();
     }
 }

--- a/src/main/java/com/apptive/marico/dto/stylistService/StylistFilterDto.java
+++ b/src/main/java/com/apptive/marico/dto/stylistService/StylistFilterDto.java
@@ -1,0 +1,14 @@
+package com.apptive.marico.dto.stylistService;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class StylistFilterDto {
+
+    private String style;
+    private String city;
+    private String gender;
+}

--- a/src/main/java/com/apptive/marico/dto/token/TokenRequestDto.java
+++ b/src/main/java/com/apptive/marico/dto/token/TokenRequestDto.java
@@ -6,5 +6,4 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TokenRequestDto {
     private String accessToken;
-    private String refreshToken;
 }

--- a/src/main/java/com/apptive/marico/entity/Member.java
+++ b/src/main/java/com/apptive/marico/entity/Member.java
@@ -1,5 +1,6 @@
 package com.apptive.marico.entity;
 
+import com.apptive.marico.dto.AccountDto;
 import com.apptive.marico.entity.token.VerificationToken;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -89,7 +90,11 @@ public class Member implements UserDetails {
     // 참고 사항
     private String note; // 필수
 
-
+    public void setAccount(AccountDto accountDto) {
+        this.bank = accountDto.getBank();
+        this.accountNumber = accountDto.getAccountNumber();
+        this.accountHolder = accountDto.getAccountHolder();
+    }
 
 
     @Column(nullable = false)

--- a/src/main/java/com/apptive/marico/entity/Member.java
+++ b/src/main/java/com/apptive/marico/entity/Member.java
@@ -62,6 +62,12 @@ public class Member implements UserDetails {
 
     private String weight; // 필수
 
+    private String bank;
+
+    private String accountNumber;
+
+    private String accountHolder;
+
     @ManyToMany
     @JoinTable(
             name = "member_style",

--- a/src/main/java/com/apptive/marico/entity/Member.java
+++ b/src/main/java/com/apptive/marico/entity/Member.java
@@ -30,7 +30,7 @@ public class Member implements UserDetails {
     @Column(nullable = false)
     private String name;
 
-    @Column(updatable = false,unique = true,nullable = false)
+    @Column(unique = true,nullable = false)
     private String email;
 
     @Column(updatable = false, unique = true, nullable = false)

--- a/src/main/java/com/apptive/marico/entity/ServiceApplication.java
+++ b/src/main/java/com/apptive/marico/entity/ServiceApplication.java
@@ -1,0 +1,27 @@
+package com.apptive.marico.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ServiceApplication {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private StylistService stylistService;
+
+    @ManyToOne
+    private Member member;
+
+}

--- a/src/main/java/com/apptive/marico/entity/ServiceInquiry.java
+++ b/src/main/java/com/apptive/marico/entity/ServiceInquiry.java
@@ -44,4 +44,9 @@ public class ServiceInquiry {
     private List<String> responseImg = new ArrayList<>();
 
     private boolean answerComplete = false;
+
+    public void addAnswer(String responseContent, List<String> responseImg) {
+        this.responseContent = responseContent;
+        this.responseImg = responseImg;
+    }
 }

--- a/src/main/java/com/apptive/marico/entity/ServiceInquiry.java
+++ b/src/main/java/com/apptive/marico/entity/ServiceInquiry.java
@@ -48,5 +48,6 @@ public class ServiceInquiry {
     public void addAnswer(String responseContent, List<String> responseImg) {
         this.responseContent = responseContent;
         this.responseImg = responseImg;
+        this.answerComplete = true;
     }
 }

--- a/src/main/java/com/apptive/marico/entity/Stylist.java
+++ b/src/main/java/com/apptive/marico/entity/Stylist.java
@@ -1,5 +1,6 @@
 package com.apptive.marico.entity;
 
+import com.apptive.marico.dto.AccountDto;
 import com.apptive.marico.dto.stylist.StylistMypageEditDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -62,6 +63,12 @@ public class Stylist implements UserDetails {
 
     private String chat_link;
 
+    private String bank;
+
+    private String accountNumber;
+
+    private String accountHolder;
+
     @OneToMany(mappedBy = "stylist" , cascade = CascadeType.ALL, orphanRemoval = true) // 연결이 끊어진 career는 자동 삭제
     private List<Career> career;
 
@@ -96,6 +103,12 @@ public class Stylist implements UserDetails {
 
     public void changeEmail(String email) {
         this.email = email;
+    }
+
+    public void setAccount(AccountDto accountDto) {
+        this.bank = accountDto.getBank();
+        this.accountNumber = accountDto.getAccountNumber();
+        this.accountHolder = accountDto.getAccountHolder();
     }
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/apptive/marico/entity/Stylist.java
+++ b/src/main/java/com/apptive/marico/entity/Stylist.java
@@ -71,6 +71,9 @@ public class Stylist implements UserDetails {
     @OneToMany(mappedBy = "stylist", orphanRemoval = true)
     private List<NoticeReadStatus> noticeReadStatuses = new ArrayList<>();
 
+    @OneToMany(mappedBy = "stylist", orphanRemoval = true)
+    private List<StylistService> stylistServices = new ArrayList<>();
+
     @Column(nullable = false)
     private boolean enabled;
 

--- a/src/main/java/com/apptive/marico/exception/ErrorCode.java
+++ b/src/main/java/com/apptive/marico/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
 
     VERIFICATION_CODE_INVALID(401, "발급 코드가 유효하지 않습니다."),
     EMAIL_DOES_NOT_MATCH(401, "이메일이 일치하지 않습니다."),
+    AUTHORIZATION_NOT_FOUND(401, "인증 헤더가 누락되었습니다. 요청에 'AUTHORIZATION' 헤더를 포함해주세요."),
 
     //403 Forbidden 요청이 이해되었지만 서버가 요청을 거부했음
     TOO_MANY_SERVICES(403, "등록할 수 있는 서비스 갯수를 초과했습니다."),

--- a/src/main/java/com/apptive/marico/jwt/CheckPrincipalAspect.java
+++ b/src/main/java/com/apptive/marico/jwt/CheckPrincipalAspect.java
@@ -1,0 +1,22 @@
+package com.apptive.marico.jwt;
+
+import com.apptive.marico.exception.CustomException;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+
+import static com.apptive.marico.exception.ErrorCode.AUTHORIZATION_NOT_FOUND;
+
+@Aspect
+@Component
+public class CheckPrincipalAspect {
+
+    @Before("execution(* com.apptive.marico.controller..*.*(..)) && args(principal,..)")
+    public void checkPrincipal(Principal principal) {
+        if (principal == null) {
+            throw new CustomException(AUTHORIZATION_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/apptive/marico/repository/ServiceApplicationRepository.java
+++ b/src/main/java/com/apptive/marico/repository/ServiceApplicationRepository.java
@@ -1,0 +1,10 @@
+package com.apptive.marico.repository;
+
+import com.apptive.marico.entity.Role;
+import com.apptive.marico.entity.ServiceApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ServiceApplicationRepository extends JpaRepository<ServiceApplication, Long> {
+}

--- a/src/main/java/com/apptive/marico/repository/StylistRepository.java
+++ b/src/main/java/com/apptive/marico/repository/StylistRepository.java
@@ -23,6 +23,8 @@ public interface StylistRepository extends JpaRepository<Stylist,Long> {
     @Query("SELECT s FROM Stylist s LEFT JOIN FETCH s.noticeReadStatuses WHERE s.userId = :userId")
     Optional<Stylist> findByUserIdWithNoticeReadStatus(String userId);
 
+    @Query("SELECT DISTINCT s FROM Stylist s LEFT JOIN FETCH s.stylistServices WHERE s.id = :stylistId")
+    Optional<Stylist> findByIdWithService(Long stylistId);
 
     // styles 값이 파라미터로 주어진 컬렉션에 포함되어 있는 스타일리스트 엔티티들을 조회한다.
     List<Stylist> findByStylesIn(List<Style> styles);

--- a/src/main/java/com/apptive/marico/service/HomeService.java
+++ b/src/main/java/com/apptive/marico/service/HomeService.java
@@ -1,20 +1,34 @@
 package com.apptive.marico.service;
 
+import com.apptive.marico.dto.AccountDto;
+import com.apptive.marico.dto.ServiceApplicationDto;
 import com.apptive.marico.dto.stylist.StylistDetailDto;
 import com.apptive.marico.dto.stylistService.StylistFilterDto;
+import com.apptive.marico.entity.Member;
+import com.apptive.marico.entity.ServiceApplication;
 import com.apptive.marico.entity.Stylist;
+import com.apptive.marico.entity.StylistService;
 import com.apptive.marico.exception.CustomException;
+import com.apptive.marico.repository.MemberRepository;
+import com.apptive.marico.repository.ServiceApplicationRepository;
 import com.apptive.marico.repository.StylistRepository;
+import com.apptive.marico.repository.StylistServiceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import static com.apptive.marico.exception.ErrorCode.SERVICE_NOT_FOUND;
 import static com.apptive.marico.exception.ErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class HomeService {
 
     private final StylistRepository stylistRepository;
+    private final MemberRepository memberRepository;
+    private final StylistServiceRepository stylistServiceRepository;
+    private final ServiceApplicationRepository serviceApplicationRepository;
 
     public String filter(StylistFilterDto stylistFilterDto) {
         return "0";
@@ -24,5 +38,41 @@ public class HomeService {
         Stylist stylist = stylistRepository.findByIdWithService(stylistId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         return StylistDetailDto.toDto(stylist);
+    }
+
+    public ServiceApplicationDto loadApplication(String userId, Long serviceId) {
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        StylistService stylistService = stylistServiceRepository.findServiceWithStylistById(serviceId)
+                .orElseThrow(() -> new CustomException(SERVICE_NOT_FOUND));
+
+        Stylist stylist = stylistService.getStylist();
+        return ServiceApplicationDto.builder()
+                .refundAccount(AccountDto.builder()
+                        .bank(member.getBank())
+                        .accountHolder(member.getAccountHolder())
+                        .accountNumber(member.getAccountNumber())
+                        .build())
+                .stylistAccount(AccountDto.builder()
+                        .bank(stylist.getBank())
+                        .accountHolder(stylist.getAccountHolder())
+                        .accountNumber(stylist.getAccountNumber())
+                        .build())
+                .build();
+    }
+
+    public String addApplication(String userId, Long serviceId) {
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        StylistService stylistService = stylistServiceRepository.findServiceWithStylistById(serviceId)
+                .orElseThrow(() -> new CustomException(SERVICE_NOT_FOUND));
+
+        serviceApplicationRepository.save(ServiceApplication.builder()
+                .member(member)
+                .stylistService(stylistService)
+                .build());
+        return "서비스 신청이 정상적으로 접수되었습니다.";
     }
 }

--- a/src/main/java/com/apptive/marico/service/HomeService.java
+++ b/src/main/java/com/apptive/marico/service/HomeService.java
@@ -1,0 +1,28 @@
+package com.apptive.marico.service;
+
+import com.apptive.marico.dto.stylist.StylistDetailDto;
+import com.apptive.marico.dto.stylistService.StylistFilterDto;
+import com.apptive.marico.entity.Stylist;
+import com.apptive.marico.exception.CustomException;
+import com.apptive.marico.repository.StylistRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.apptive.marico.exception.ErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class HomeService {
+
+    private final StylistRepository stylistRepository;
+
+    public String filter(StylistFilterDto stylistFilterDto) {
+        return "0";
+    }
+
+    public StylistDetailDto stylistDetail(Long stylistId) {
+        Stylist stylist = stylistRepository.findByIdWithService(stylistId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        return StylistDetailDto.toDto(stylist);
+    }
+}

--- a/src/main/java/com/apptive/marico/service/InquiryService.java
+++ b/src/main/java/com/apptive/marico/service/InquiryService.java
@@ -32,16 +32,17 @@ public class InquiryService {
     private final StylistServiceRepository stylistServiceRepository;
     private final StylistRepository stylistRepository;
     private final ImageUploadService imageUploadService;
-    public String addInquiry(String userId, InquiryDto inquiryDto) {
+    public String addInquiry(String userId, List<MultipartFile> image, InquiryDto inquiryDto) {
         Member member = memberRepository.findByUserId(userId)
                             .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         StylistService stylistService = stylistServiceRepository.findById(inquiryDto.getService_id())
                                             .orElseThrow(() -> new CustomException(SERVICE_NOT_FOUND));
+        List<String> img = imageUploadService.upload(image);
         inquiryRepository.save(ServiceInquiry.builder()
                                 .title(inquiryDto.getTitle())
                                 .content(inquiryDto.getContent())
                                 .member(member)
-                                .inquiryImg(inquiryDto.getImg())
+                                .inquiryImg(img)
                                 .stylistService(stylistService)
                                 .build());
         return "문의사항이 등록 되었습니다.";

--- a/src/main/java/com/apptive/marico/service/InquiryService.java
+++ b/src/main/java/com/apptive/marico/service/InquiryService.java
@@ -14,6 +14,7 @@ import com.apptive.marico.repository.StylistServiceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,6 +31,7 @@ public class InquiryService {
     private final InquiryRepository inquiryRepository;
     private final StylistServiceRepository stylistServiceRepository;
     private final StylistRepository stylistRepository;
+    private final ImageUploadService imageUploadService;
     public String addInquiry(String userId, InquiryDto inquiryDto) {
         Member member = memberRepository.findByUserId(userId)
                             .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -44,10 +46,6 @@ public class InquiryService {
                                 .build());
         return "문의사항이 등록 되었습니다.";
     }
-
-//    public InquiryDto loadInquiry(String userId) {
-//
-//    }
 
     public InquiryPreviewDto.DtoList loadInquiryList (String userId) {
         Optional<Member> member = memberRepository.findByUserId(userId);
@@ -84,8 +82,26 @@ public class InquiryService {
         List<StylistService> stylistServiceList = stylistServiceRepository.findAllByStylistUserId(userId);
         ServiceInquiry serviceInquiry = inquiryRepository.findById(inquiryId)
                 .orElseThrow(() -> new CustomException(INQUIRY_NOT_FOUND));
+        isMatchInquiryWithStylist(stylistServiceList, serviceInquiry);
+        return InquiryDto.toDto(serviceInquiry);
+    }
+
+    public String addInquiryAnswer(String userId, Long inquiry_id, String responseContent, List<MultipartFile> answerImgs) {
+        List<StylistService> stylistServiceList= stylistServiceRepository.findAllByStylistUserId(userId);
+
+        ServiceInquiry serviceInquiry = inquiryRepository.findById(inquiry_id)
+                .orElseThrow(() -> new CustomException(INQUIRY_NOT_FOUND));
+        isMatchInquiryWithStylist(stylistServiceList, serviceInquiry);
+        // 답변 이미지 등록
+        List<String> imgNameList = imageUploadService.upload(answerImgs);
+        serviceInquiry.addAnswer(responseContent, imgNameList);
+
+        return "답변이 등록되었습니다.";
+    }
+
+    private void isMatchInquiryWithStylist(List<StylistService> stylistServiceList, ServiceInquiry serviceInquiry) {
+
         StylistService stylistService = serviceInquiry.getStylistService();
         if (!stylistServiceList.contains(stylistService)) throw new CustomException(USER_AND_INQUIRY_NOT_MATCH);
-        return InquiryDto.toDto(serviceInquiry);
     }
 }

--- a/src/main/java/com/apptive/marico/service/MemberHomeService.java
+++ b/src/main/java/com/apptive/marico/service/MemberHomeService.java
@@ -2,6 +2,7 @@ package com.apptive.marico.service;
 
 import com.apptive.marico.dto.RecommendStylistDto;
 import com.apptive.marico.entity.Member;
+import com.apptive.marico.entity.Style;
 import com.apptive.marico.entity.Stylist;
 import com.apptive.marico.exception.CustomException;
 import com.apptive.marico.exception.ErrorCode;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -24,44 +26,51 @@ import static com.apptive.marico.exception.ErrorCode.USER_NOT_FOUND;
 public class MemberHomeService {
     private final MemberRepository memberRepository;
     private final StylistRepository stylistRepository;
+
     public List<RecommendStylistDto> recommendStylist(String userId) {
         Member member = memberRepository.findByUserId(userId).orElseThrow(
                 () -> new CustomException(USER_NOT_FOUND));
 
-        // 추천 기준: 선호 스타일 > 지역(근거리 순)
+        // 모든 스타일리스트를 가져온다.
+        List<Stylist> allStylists = stylistRepository.findAll();
 
-        // 선호 스타일을 가지고 있는 스타일리스트 찾기
-        List<Stylist> preferredStylists = stylistRepository.findByStylesIn(member.getPreferredStyles());
-
-        preferredStylists = preferredStylists.stream()
-                .filter(stylist -> {
-                    // stylist와 member의 city와 state 값 중 null이 있는 경우 필터링에서 제외
-                    String stylistCity = Optional.ofNullable(stylist.getCity()).orElse("");
-                    String stylistState = Optional.ofNullable(stylist.getState()).orElse("");
-                    String memberCity = Optional.ofNullable(member.getCity()).orElse("");
-                    String memberState = Optional.ofNullable(member.getState()).orElse("");
-
-                    // city와 state가 모두 일치하는 경우에만 필터링
-                    return stylistCity.equals(memberCity) && stylistState.equals(memberState);
-                })
-                .sorted(Comparator.comparing(Stylist::getCity).thenComparing(Stylist::getState))
+        // 각 스타일리스트에 대해 점수를 계산하고, 이를 기준으로 정렬한다.
+        List<Stylist> sortedStylists = allStylists.stream()
+                .sorted(Comparator.comparing(stylist -> -calculateScore(member, stylist)))
                 .collect(Collectors.toList());
-
-//        // 선호 스타일과 지역을 모두 만족하는 스타일리스트가 10명 미만일 경우, 선호 스타일만 고려하여 스타일리스트 찾기
-//        if(preferredStylists.size() < 10) {
-//            preferredStylists.addAll(stylistRepository.findByStylesInAndCityNotOrStateNot(member.getPreferredStyles(), member.getCity(), member.getState()));
-//        }
+        System.out.println(sortedStylists.get(0) + ", " + sortedStylists.get(1));
 
         // 추천 스타일리스트가 10명이 넘을 경우, 리스트 크기 조정
-        if(preferredStylists.size() > 10) {
-            preferredStylists = preferredStylists.subList(0, 10);
+        if(sortedStylists.size() > 10) {
+            sortedStylists = sortedStylists.subList(0, 10);
         }
 
         // 추천 스타일리스트 정보를 RecommendStylistDto에 담아 반환
-        List<RecommendStylistDto> recommendStylistDtos = preferredStylists.stream()
+        List<RecommendStylistDto> recommendStylistDtos = sortedStylists.stream()
                 .map(stylist -> new RecommendStylistDto(stylist.getId(), stylist.getProfileImage(), stylist.getOneLineIntroduction(), stylist.getStageName()))
                 .collect(Collectors.toList());
 
         return recommendStylistDtos;
+    }
+
+    private double calculateScore(Member member, Stylist stylist) {
+        double score = 0;
+
+        // 선호 스타일이 일치하는 경우
+        for (Style preferredStyle : member.getPreferredStyles()) {
+            if (stylist.getStyles().contains(preferredStyle)) {
+                score += 10;
+            }
+        }
+
+        // 도시와 상태가 모두 일치하는 경우
+        if(Objects.equals(stylist.getCity(), member.getCity()) && Objects.equals(stylist.getState(), member.getState())) {
+            score += 5;
+        }
+        // 도시만 일치하는 경우
+        else if (Objects.equals(stylist.getCity(), member.getCity())) {
+            score += 2.5;
+        }
+        return score;
     }
 }

--- a/src/main/java/com/apptive/marico/service/MemberMypageService.java
+++ b/src/main/java/com/apptive/marico/service/MemberMypageService.java
@@ -126,9 +126,9 @@ public class MemberMypageService {
         Member member = memberRepository.findByUserId(userId).orElseThrow(
                 () -> new CustomException(USER_NOT_FOUND));
 
-
         member.setEmail(newEmail);
-        memberRepository.save(member);
+        Member save = memberRepository.save(member);
+        System.out.println(save.getEmail());
 
         return "이메일이 정상적으로 변경되었습니다.";
     }

--- a/src/main/java/com/apptive/marico/service/MemberMypageService.java
+++ b/src/main/java/com/apptive/marico/service/MemberMypageService.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.apptive.marico.dto.AccountDto;
 import com.apptive.marico.dto.mypage.member.MemberMypageDto;
 import com.apptive.marico.dto.mypage.member.LikedStylistDto;
 import com.apptive.marico.dto.mypage.member.LikedStylistListDto;
@@ -190,5 +191,23 @@ public class MemberMypageService {
         } catch (StringIndexOutOfBoundsException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일(" + fileName + ") 입니다.");
         }
+    }
+
+    public AccountDto loadAccount(String userId) {
+        Member member = memberRepository.findByUserId(userId).orElseThrow(
+                () -> new CustomException(USER_NOT_FOUND));
+        return AccountDto.builder()
+                .bank(member.getBank())
+                .accountHolder(member.getAccountHolder())
+                .accountNumber(member.getAccountNumber())
+                .build();
+    }
+
+    public String addAccount(String userId, AccountDto accountDto) {
+        Member member = memberRepository.findByUserId(userId).orElseThrow(
+                () -> new CustomException(USER_NOT_FOUND));
+        member.setAccount(accountDto);
+        memberRepository.save(member);
+        return "계좌정보가 정상적으로 등록되었습니다.";
     }
 }

--- a/src/main/java/com/apptive/marico/service/MemberMypageService.java
+++ b/src/main/java/com/apptive/marico/service/MemberMypageService.java
@@ -192,7 +192,6 @@ public class MemberMypageService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일(" + fileName + ") 입니다.");
         }
     }
-
     public AccountDto loadAccount(String userId) {
         Member member = memberRepository.findByUserId(userId).orElseThrow(
                 () -> new CustomException(USER_NOT_FOUND));
@@ -203,6 +202,7 @@ public class MemberMypageService {
                 .build();
     }
 
+    @Transactional
     public String addAccount(String userId, AccountDto accountDto) {
         Member member = memberRepository.findByUserId(userId).orElseThrow(
                 () -> new CustomException(USER_NOT_FOUND));

--- a/src/main/java/com/apptive/marico/service/StylistMypageService.java
+++ b/src/main/java/com/apptive/marico/service/StylistMypageService.java
@@ -1,4 +1,5 @@
 package com.apptive.marico.service;
+import com.apptive.marico.dto.AccountDto;
 import com.apptive.marico.dto.CareerDto;
 import com.apptive.marico.dto.stylist.*;
 import com.apptive.marico.dto.stylist.service.ServiceCategoryDto;
@@ -244,5 +245,23 @@ public class StylistMypageService {
         stylistRepository.delete(stylist);
 
         return "회원 탈퇴가 정상적으로 완료되었습니다.";
+    }
+
+    public AccountDto loadAccount(String userId) {
+        Stylist stylist = stylistRepository.findByUserId(userId).orElseThrow(
+                () -> new CustomException(USER_NOT_FOUND));
+        return AccountDto.builder()
+                .bank(stylist.getBank())
+                .accountHolder(stylist.getAccountHolder())
+                .accountNumber(stylist.getAccountNumber())
+                .build();
+    }
+
+    public String addAccount(String userId, AccountDto accountDto) {
+        Stylist stylist = stylistRepository.findByUserId(userId).orElseThrow(
+                () -> new CustomException(USER_NOT_FOUND));
+        stylist.setAccount(accountDto);
+        stylistRepository.save(stylist);
+        return "계좌정보가 정상적으로 등록되었습니다.";
     }
 }

--- a/src/main/java/com/apptive/marico/service/StylistMypageService.java
+++ b/src/main/java/com/apptive/marico/service/StylistMypageService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Objects;
@@ -33,6 +34,7 @@ public class StylistMypageService {
     private final StyleRepository styleRepository;
     private final PasswordEncoder passwordEncoder;
     private final CustomUserDetailsService customUserDetailsService;
+    private final ImageUploadService imageUploadService;
     public StylistMypageDto mypage(String userId) {
         Stylist stylist = stylistRepository.findByUserId(userId).orElseThrow(
                 () -> new CustomException(USER_NOT_FOUND));
@@ -46,7 +48,7 @@ public class StylistMypageService {
         return StylistMypageEditDto.toDto(stylist);
     }
 
-    public String editInformation(String userId, StylistMypageEditDto stylistMypageEditDto) {
+    public String editInformation(String userId, MultipartFile profileImage, StylistMypageEditDto stylistMypageEditDto) {
         Stylist stylist = stylistRepository.findByUserId(userId).orElseThrow(
                 () -> new CustomException(USER_NOT_FOUND));
 
@@ -57,6 +59,8 @@ public class StylistMypageService {
         careerDtoList.stream()
                 .map(careerDto -> createCareer(careerDto, stylist))
                 .forEach(careerRepository::save);
+        String image = imageUploadService.upload(profileImage);
+        stylistMypageEditDto.setProfile_image(image);
         stylist.editStylist(stylistMypageEditDto);
         return "정상적으로 입력되었습니다.";
     }

--- a/src/main/java/com/apptive/marico/service/StylistMypageService.java
+++ b/src/main/java/com/apptive/marico/service/StylistMypageService.java
@@ -165,11 +165,12 @@ public class StylistMypageService {
         return StyleDto.DtoList.builder().styleDtoList(styleDtoList).build();
     }
 
-    public String addStyle(String userId, StyleDto styleDto) {
+    public String addStyle(String userId,MultipartFile image ,StyleDto styleDto) {
         Optional<Stylist> stylist = stylistRepository.findByUserId(userId);
         if (stylist.isEmpty()) throw new CustomException(USER_NOT_FOUND);
+        String imgPath = imageUploadService.upload(image);
         styleRepository.save(Style.builder()
-                .image(styleDto.getImage())
+                .image(imgPath)
                 .category(styleDto.getCategory())
                 .stylist(stylist.get())
                 .build());

--- a/src/main/java/com/apptive/marico/service/VerificationTokenService.java
+++ b/src/main/java/com/apptive/marico/service/VerificationTokenService.java
@@ -10,6 +10,7 @@ import com.apptive.marico.repository.StylistRepository;
 import com.apptive.marico.repository.VerificationTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -34,6 +35,7 @@ public class VerificationTokenService {
     }
 
 
+    @Transactional
     public String createVerificationTokenForSign(String email) {
         if (isEmailRegistered(email)) {
             throw new CustomException(ALREADY_SAVED_EMAIL);
@@ -45,8 +47,9 @@ public class VerificationTokenService {
         return "인증 번호가 전송 되었습니다.";
     }
 
+    @Transactional
     public String createVerificationTokenForChangeEmail(String email) {
-        if(!memberRepository.existsByEmail(email))
+        if(memberRepository.existsByEmail(email))
             throw new CustomException(ALREADY_SAVED_EMAIL);
 
         VerificationToken token = VerificationToken.create(email);

--- a/src/main/java/com/apptive/marico/service/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/apptive/marico/service/auth/CustomUserDetailsService.java
@@ -107,9 +107,9 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     @Transactional
-    public void logout(TokenRequestDto tokenReqDto) {
+    public void logout(String accessToken) {
         // 로그아웃하려는 사용자의 정보를 가져옴
-        Authentication authentication = tokenProvider.getAuthentication(tokenReqDto.getAccessToken());
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
 
         // 저장소에서 해당 사용자의 refresh token 삭제
         refreshTokenRepository.deleteByKey(authentication.getName());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
         show_sql: true
+        default_batch_fetch_size: 100
   ## Email Send Configuration_SMTP
   mail:
     host: smtp.gmail.com

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,15 +3,15 @@ spring:
     import:
       - classpath:/application-jwt-secret.yml
       - classpath:/application-s3.yml
-#      - classpath:/application-db.yml
-  h2:
-    console:
-      enabled: true
-  datasource:
-    url: jdbc:mysql://127.0.0.1:3306/marico
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    username: root
-    password: 1234
+      - classpath:/application-db.yml
+#  h2:
+#    console:
+#      enabled: true
+#  datasource:
+#    url: jdbc:mysql://127.0.0.1:3310/marico
+#    driver-class-name: com.mysql.cj.jdbc.Driver
+#    username: root
+#    password: 1234
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
# 변경점 👍
- 이메일 인증-이메일 변경api에서 이메일이 update 되지 않는 오류 해결
- 스타일리스트 추천: 선호스타일이 일치하는 스타일리스트 중에서 지역에 따라 정렬하여 추천 -> 점수제도로 변경

# 리팩토링 🛠
- 요청 헤더에 인증 코드 없을 때 오류 메세지 띄우기

